### PR TITLE
Fix connection module import handling for all-uppercase service types

### DIFF
--- a/ingestion/src/metadata/ingestion/api/parser.py
+++ b/ingestion/src/metadata/ingestion/api/parser.py
@@ -276,7 +276,13 @@ def get_connection_class(
     # From metadata.generated.schema.entity.services.databaseService we get metadata.generated.schema.entity.services
     module_path = ".".join(service_type.__module__.split(".")[:-1])
     connection_path = service_type.__name__.lower().replace("connection", "")
-    connection_module = source_type[0].lower() + source_type[1:] + "Connection"
+
+    # Handle all-uppercase source types (e.g., SAS, SSAS) by lowercasing entirely
+    # For mixed-case types (e.g., BigQuery, AzureSQL), lowercase only the first character
+    if source_type.isupper():
+        connection_module = source_type.lower() + "Connection"
+    else:
+        connection_module = source_type[0].lower() + source_type[1:] + "Connection"
 
     class_name = source_type + "Connection"
     class_path = f"{module_path}.connections.{connection_path}.{connection_module}"

--- a/ingestion/tests/unit/test_workflow_parse.py
+++ b/ingestion/tests/unit/test_workflow_parse.py
@@ -122,6 +122,22 @@ class TestWorkflowParse(TestCase):
         connection = get_connection_class(source_type, get_service_type(source_type))
         self.assertEqual(connection, RestConnection)
 
+        # Test all-uppercase source types (SAS, SSAS)
+        from metadata.generated.schema.entity.services.connections.database.sasConnection import (
+            SASConnection,
+        )
+        from metadata.generated.schema.entity.services.connections.database.ssasConnection import (
+            SSASConnection,
+        )
+
+        source_type = "SAS"
+        connection = get_connection_class(source_type, get_service_type(source_type))
+        self.assertEqual(connection, SASConnection)
+
+        source_type = "SSAS"
+        connection = get_connection_class(source_type, get_service_type(source_type))
+        self.assertEqual(connection, SSASConnection)
+
     def test_get_source_config_class(self):
         """
         Check that we can correctly build the connection module ingredients


### PR DESCRIPTION
This pull request improves the logic for determining the correct connection class for different source types, especially handling all-uppercase source types, and adds corresponding unit tests to ensure this behavior is correct.

**Enhancements to connection class resolution:**

* Updated `get_connection_class` in `parser.py` to handle all-uppercase source types (like `SAS`, `SSAS`) by fully lowercasing the name when constructing the connection module, while retaining the previous behavior for mixed-case types.

**Testing improvements:**

* Added unit tests in `test_workflow_parse.py` to verify that all-uppercase source types (`SAS`, `SSAS`) are correctly resolved to their respective connection classes.